### PR TITLE
989384: Authorization not working for Blazor File Manager component upload operation

### DIFF
--- a/ASPCore-FileManager-WebAPI/ASPCore-FileManager-WebAPI/Controllers/FileManagerController.cs
+++ b/ASPCore-FileManager-WebAPI/ASPCore-FileManager-WebAPI/Controllers/FileManagerController.cs
@@ -95,12 +95,13 @@ namespace ASPCore_FileManager_WebAPI.Controllers
         //[HttpPost]
         [Route("Upload")]
         [Authorize(Roles = "Admin")]
-        public IActionResult Upload(string path, IList<IFormFile> uploadFiles, string action)
+        [DisableRequestSizeLimit]
+        public IActionResult Upload(string path, long size,IList<IFormFile> uploadFiles, string action)
         {
             FileManagerResponse uploadResponse;
             foreach (var file in uploadFiles)
             {
-                var folders = (file.FileName).Split('/');
+                var folders = (file.FileName ?? string.Empty).Split('/');
                 // checking the folder upload
                 if (folders.Length > 1)
                 {
@@ -115,7 +116,7 @@ namespace ASPCore_FileManager_WebAPI.Controllers
                     }
                 }
             }
-            uploadResponse = operation.Upload(path, uploadFiles, action, null);
+            uploadResponse = operation.Upload(path, uploadFiles, action, size);
             if (uploadResponse.Error != null)
             {
                 Response.Clear();

--- a/ASPCore-FileManager-WebAPI/ASPCore-FileManager-WebAPI/Program.cs
+++ b/ASPCore-FileManager-WebAPI/ASPCore-FileManager-WebAPI/Program.cs
@@ -6,11 +6,12 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddRazorPages();
+builder.Services.AddControllers();
 builder.Services.AddCors(options =>
 {
-    options.AddPolicy("AllowAllOrigins", builder =>
+    options.AddPolicy("AllowAllOrigins", policy =>
     {
-        builder.AllowAnyOrigin()
+        policy.AllowAnyOrigin()
         .AllowAnyMethod()
         .AllowAnyHeader();
     });
@@ -41,13 +42,10 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 
 app.UseRouting();
+app.UseCors("AllowAllOrigins");
 app.UseAuthentication();
 app.UseAuthorization();
 
+app.MapControllers();
 app.MapRazorPages();
-app.UseCors("AllowAllOrigins");
-app.UseEndpoints(endPoints =>
-{
-    endPoints.MapControllers();
-});
 app.Run();


### PR DESCRIPTION
### Bug description
[989384](https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/989384) - Authorization not working for Blazor File Manager component upload operation. 

### Root cause
CORS origin restriction caused preflight requests to fail with 401 Unauthorized and Duplicate Authorization headers were being added: one from the HttpClient instance and another from GetCustomHeaders and facing an issue during chunck upload due to JWT sample provider lacked chunk-aware upload handling, so each chunk was treated as a full upload.
 
### Solution description
Updated the CORS policy in Program.cs by correcting the AddPolicy syntax, moving UseCors before authentication/authorization, and replacing UseEndpoints with MapControllers. Additionally, fixed the duplicate header issue in GetCustomHeaders by skipping the Authorization header when building custom header, Implemented chunk-aware upload in the JWT PhysicalFileProvider by porting the logic from ej2-aspcore-fileprovider PhysicalFileProvider.cs

### Impact assessment
* [x] Low - Affects a single feature with minimal user impact
* [ ] Medium - Affects multiple features or has moderate user impact
* [ ] High - Critical functionality or significant user impact

### Reason for not identifying earlier
The issues are occurred only in specific scenario
     
### Areas tested against this fix
Tested Conditions
* [x] Verified file upload works correctly with and without the Authorization header
* [x] Confirmed upload action functions properly in both FormSubmit and HttpClient modes.
* [x] Tested single and multiple file uploads with authorization enabled
* [x] Validated directory upload with authorization.
* [x] Ensured whether the chunck upload works properly with and without authoriization headers 
* [x] Checked duplicate file uploads with KeepBoth, Skip, and Replace options
* [x] Attempted upload with an invalid issuer to ensure proper error handling
* [x] Verified upload behavior when AutoUpload and AutoClose are set to both true and false.
* [x] Tested upload with disallowed file extensions.
* [x] Ensured upload fails when role is set to user insist of admin   


### Breaking changes
* [x] Yes (Tag `breaking-issue`)
* [ ] No
 
If yes, provide breaking commit details link and migration guidance.
https://gitea.syncfusion.com/essential-studio/ej2-blazor-source/pulls/24031

### Regression testing
* [x] Verified fix doesn't reintroduce previous bugs
* [x] Checked edge cases and error scenarios

### Action taken to prevent recurrence
* [ ] Added/updated unit tests
* [ ] Other (specify)
* [x] NA

### Automation status
* [x] BUnit ((Automation work assigned to testing team to avoid this in the future))
* [ ] Playwight (provide PR link: _________________)
* [ ] NA

### Cross-platform verification
* [x] Blazor Server
* [x] Blazor WASM
* [ ] NA
 
### Related issues
Is this issue present in EJ2 or other components?
* [ ] Resolved in EJ2 (PR link: _________________)
* [ ] Created task for EJ2 (Task link: _________________)
* [ ] Needs attention in other components (tag `needs-attention-coreteam`)
* [x] NA

### Output screenshots
Before Fix:
<img width="1743" height="915" alt="image" src="https://github.com/user-attachments/assets/5c8fd8df-7d33-43ce-8213-f331acf71ed6" />

After fix:
<img width="1724" height="974" alt="image" src="https://github.com/user-attachments/assets/3047a0c3-0333-4252-94f3-f0ee806112f3" />

### API changes
* [ ] New API added (API Review task link: _________________)
* [ ] Existing API renamed/modified (API Review task link: _________________)
* [x] No API changes

### Performance verification
* [x] Verified no memory leaks introduced
* [x] Verified no performance degradation
* [ ] Not applicable

### Reviewer Checklist
* [x] Feature matrix documentation verified
* [x] Test coverage verified
* [x] Sample implementation reviewed
* [x] Code meets standards and best practices
* [x] C# implementation used appropriately (minimal JavaScript)